### PR TITLE
fix resolve path error

### DIFF
--- a/oz.js
+++ b/oz.js
@@ -571,7 +571,7 @@
 
     exports.resolvename = function(url){
         url = url.replace(_RE_DOT, '$1');
-        var dots, dots_n, url_dup = url, RE_DOTS = /(\.\.\/)+/g;
+        var dots, dots_n, url_dup = url, RE_DOTS = /(\.\.\/)/g;
         while (dots = (RE_DOTS.exec(url_dup) || [])[0]) {
             dots_n = dots.match(/\.\.\//g).length;
             dots = dots.replace(/\./, '\\.');


### PR DESCRIPTION
``` coffeescript
# bofore
oz.resolvename('../dist/whatever/keith/../../')
>>> "../dist/whatever/../"
# after 
oz.resolvename('../dist/whatever/keith/../../')
>>> "../dist/"
```

Found ozjs broken in loading jQuery's source code(which is also amd modules).
